### PR TITLE
Also add new_with_buffer_capacity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ license = "MIT/Apache-2.0"
 tempfile = "3.0.5"
 
 [dependencies]
-chrono = "0.4.22"
+chrono = "0.4.23"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ license = "MIT/Apache-2.0"
 tempfile = "3.0.5"
 
 [dependencies]
-chrono = "0.4"
+chrono = "0.4.22"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,7 +227,7 @@ where
         for i in (0..self.max_files.max(1)).rev() {
             let rotate_from = self.filename_for(i);
             let rotate_to = self.filename_for(i + 1);
-            if let Err(e) = fs::rename(&rotate_from, &rotate_to).or_else(|e| match e.kind() {
+            if let Err(e) = fs::rename(rotate_from, rotate_to).or_else(|e| match e.kind() {
                 io::ErrorKind::NotFound => Ok(()),
                 _ => Err(e),
             }) {
@@ -267,7 +267,7 @@ where
 
     /// Writes data using the given datetime to calculate the rolling condition
     pub fn write_with_datetime(&mut self, buf: &[u8], now: &DateTime<Local>) -> io::Result<usize> {
-        if self.condition.should_rollover(&now, self.current_filesize) {
+        if self.condition.should_rollover(now, self.current_filesize) {
             if let Err(e) = self.rollover() {
                 // If we can't rollover, just try to continue writing anyway
                 // (better than missing data).
@@ -364,7 +364,7 @@ mod t {
         c.rolling
             .write_with_datetime(b"Line 5\n", &Local.ymd(2022, 5, 31).and_hms(1, 4, 0))
             .unwrap();
-        assert_eq!(AsRef::<Path>::as_ref(&c.rolling.filename_for(4)).exists(), false);
+        assert!(!AsRef::<Path>::as_ref(&c.rolling.filename_for(4)).exists());
         c.verify_contains("Line 1", 3);
         c.verify_contains("Line 2", 3);
         c.verify_contains("Line 3", 2);
@@ -390,8 +390,8 @@ mod t {
         c.rolling
             .write_with_datetime(b"Line 5\n", &Local.ymd(2022, 5, 31).and_hms(1, 4, 0))
             .unwrap();
-        assert_eq!(AsRef::<Path>::as_ref(&c.rolling.filename_for(4)).exists(), false);
-        assert_eq!(AsRef::<Path>::as_ref(&c.rolling.filename_for(3)).exists(), false);
+        assert!(!AsRef::<Path>::as_ref(&c.rolling.filename_for(4)).exists());
+        assert!(!AsRef::<Path>::as_ref(&c.rolling.filename_for(3)).exists());
         c.verify_contains("Line 3", 2);
         c.verify_contains("Line 4", 1);
         c.verify_contains("Line 5", 0);
@@ -412,7 +412,7 @@ mod t {
         c.rolling
             .write_with_datetime(b"Line 4\n", &Local.ymd(2021, 3, 31).and_hms(2, 1, 0))
             .unwrap();
-        assert_eq!(AsRef::<Path>::as_ref(&c.rolling.filename_for(3)).exists(), false);
+        assert!(!AsRef::<Path>::as_ref(&c.rolling.filename_for(3)).exists());
         c.verify_contains("Line 1", 2);
         c.verify_contains("Line 2", 2);
         c.verify_contains("Line 3", 1);
@@ -440,7 +440,7 @@ mod t {
         c.rolling
             .write_with_datetime(b"Line 6\n", &Local.ymd(2022, 3, 30).and_hms(2, 3, 0))
             .unwrap();
-        assert_eq!(AsRef::<Path>::as_ref(&c.rolling.filename_for(4)).exists(), false);
+        assert!(!AsRef::<Path>::as_ref(&c.rolling.filename_for(4)).exists());
         c.verify_contains("Line 1", 3);
         c.verify_contains("Line 2", 3);
         c.verify_contains("Line 3", 3);
@@ -467,7 +467,7 @@ mod t {
         c.rolling
             .write_with_datetime(b"ZZZ", &Local.ymd(2022, 3, 31).and_hms(1, 2, 3))
             .unwrap();
-        assert_eq!(AsRef::<Path>::as_ref(&c.rolling.filename_for(3)).exists(), false);
+        assert!(!AsRef::<Path>::as_ref(&c.rolling.filename_for(3)).exists());
         c.verify_contains("1234567890", 2);
         c.verify_contains("abcdefghijklmn", 1);
         c.verify_contains("ZZZ", 0);
@@ -495,7 +495,7 @@ mod t {
         c.rolling
             .write_with_datetime(b"ZZZ", &Local.ymd(2022, 3, 31).and_hms(1, 2, 3))
             .unwrap();
-        assert_eq!(AsRef::<Path>::as_ref(&c.rolling.filename_for(3)).exists(), false);
+        assert!(!AsRef::<Path>::as_ref(&c.rolling.filename_for(3)).exists());
         c.verify_contains("1234567890", 2);
         c.verify_contains("abcdefghijklmn", 1);
         c.verify_contains("ZZZ", 0);
@@ -519,7 +519,7 @@ mod t {
         c.rolling
             .write_with_datetime(b"ZZZ", &Local.ymd(2021, 3, 31).and_hms(4, 4, 4))
             .unwrap();
-        assert_eq!(AsRef::<Path>::as_ref(&c.rolling.filename_for(3)).exists(), false);
+        assert!(!AsRef::<Path>::as_ref(&c.rolling.filename_for(3)).exists());
         c.verify_contains("123456789", 2);
         c.verify_contains("0abcdefghijklmn", 1);
         c.verify_contains("ZZZ", 0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -586,9 +586,9 @@ mod t {
         c.verify_not_contains("12345", 0);
 
         // implicit flush only after capacity is reached
-        for data in std::iter::repeat(b"dummy") {
+        loop {
             c.rolling
-                .write_with_datetime(data, &Local.ymd(2021, 3, 30).and_hms(1, 2, 3))
+                .write_with_datetime(b"dummy", &Local.ymd(2021, 3, 30).and_hms(1, 2, 3))
                 .unwrap();
             if c.rolling.current_filesize <= 100_000 {
                 c.verify_not_contains("dummy", 0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -586,13 +586,11 @@ mod t {
         c.verify_not_contains("12345", 0);
 
         // implicit flush only after capacity is reached
-        let mut count = 0;
         for data in std::iter::repeat(b"dummy") {
             c.rolling
                 .write_with_datetime(data, &Local.ymd(2021, 3, 30).and_hms(1, 2, 3))
                 .unwrap();
-            count += data.len();
-            if count <= 100_000 {
+            if c.rolling.current_filesize <= 100_000 {
                 c.verify_not_contains("dummy", 0);
             } else {
                 break;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,13 +54,15 @@ impl RollingFrequency {
     /// different files.
     pub fn equivalent_datetime(&self, dt: &DateTime<Local>) -> DateTime<Local> {
         match self {
-            RollingFrequency::EveryDay => Local.ymd(dt.year(), dt.month(), dt.day()).and_hms(0, 0, 0),
-            RollingFrequency::EveryHour => Local.ymd(dt.year(), dt.month(), dt.day()).and_hms(dt.hour(), 0, 0),
-            RollingFrequency::EveryMinute => {
-                Local
-                    .ymd(dt.year(), dt.month(), dt.day())
-                    .and_hms(dt.hour(), dt.minute(), 0)
-            },
+            RollingFrequency::EveryDay => Local
+                .with_ymd_and_hms(dt.year(), dt.month(), dt.day(), 0, 0, 0)
+                .unwrap(),
+            RollingFrequency::EveryHour => Local
+                .with_ymd_and_hms(dt.year(), dt.month(), dt.day(), dt.hour(), 0, 0)
+                .unwrap(),
+            RollingFrequency::EveryMinute => Local
+                .with_ymd_and_hms(dt.year(), dt.month(), dt.day(), dt.hour(), dt.minute(), 0)
+                .unwrap(),
         }
     }
 }
@@ -378,19 +380,19 @@ mod t {
     fn frequency_every_day() {
         let mut c = build_context(RollingConditionBasic::new().daily(), 9, None);
         c.rolling
-            .write_with_datetime(b"Line 1\n", &Local.ymd(2021, 3, 30).and_hms(1, 2, 3))
+            .write_with_datetime(b"Line 1\n", &Local.with_ymd_and_hms(2021, 3, 30, 1, 2, 3).unwrap())
             .unwrap();
         c.rolling
-            .write_with_datetime(b"Line 2\n", &Local.ymd(2021, 3, 30).and_hms(1, 3, 0))
+            .write_with_datetime(b"Line 2\n", &Local.with_ymd_and_hms(2021, 3, 30, 1, 3, 0).unwrap())
             .unwrap();
         c.rolling
-            .write_with_datetime(b"Line 3\n", &Local.ymd(2021, 3, 31).and_hms(1, 4, 0))
+            .write_with_datetime(b"Line 3\n", &Local.with_ymd_and_hms(2021, 3, 31, 1, 4, 0).unwrap())
             .unwrap();
         c.rolling
-            .write_with_datetime(b"Line 4\n", &Local.ymd(2021, 5, 31).and_hms(1, 4, 0))
+            .write_with_datetime(b"Line 4\n", &Local.with_ymd_and_hms(2021, 5, 31, 1, 4, 0).unwrap())
             .unwrap();
         c.rolling
-            .write_with_datetime(b"Line 5\n", &Local.ymd(2022, 5, 31).and_hms(1, 4, 0))
+            .write_with_datetime(b"Line 5\n", &Local.with_ymd_and_hms(2022, 5, 31, 1, 4, 0).unwrap())
             .unwrap();
         assert!(!AsRef::<Path>::as_ref(&c.rolling.filename_for(4)).exists());
         c.flush();
@@ -405,19 +407,19 @@ mod t {
     fn frequency_every_day_limited_files() {
         let mut c = build_context(RollingConditionBasic::new().daily(), 2, None);
         c.rolling
-            .write_with_datetime(b"Line 1\n", &Local.ymd(2021, 3, 30).and_hms(1, 2, 3))
+            .write_with_datetime(b"Line 1\n", &Local.with_ymd_and_hms(2021, 3, 30, 1, 2, 3).unwrap())
             .unwrap();
         c.rolling
-            .write_with_datetime(b"Line 2\n", &Local.ymd(2021, 3, 30).and_hms(1, 3, 0))
+            .write_with_datetime(b"Line 2\n", &Local.with_ymd_and_hms(2021, 3, 30, 1, 3, 0).unwrap())
             .unwrap();
         c.rolling
-            .write_with_datetime(b"Line 3\n", &Local.ymd(2021, 3, 31).and_hms(1, 4, 0))
+            .write_with_datetime(b"Line 3\n", &Local.with_ymd_and_hms(2021, 3, 31, 1, 4, 0).unwrap())
             .unwrap();
         c.rolling
-            .write_with_datetime(b"Line 4\n", &Local.ymd(2021, 5, 31).and_hms(1, 4, 0))
+            .write_with_datetime(b"Line 4\n", &Local.with_ymd_and_hms(2021, 5, 31, 1, 4, 0).unwrap())
             .unwrap();
         c.rolling
-            .write_with_datetime(b"Line 5\n", &Local.ymd(2022, 5, 31).and_hms(1, 4, 0))
+            .write_with_datetime(b"Line 5\n", &Local.with_ymd_and_hms(2022, 5, 31, 1, 4, 0).unwrap())
             .unwrap();
         assert!(!AsRef::<Path>::as_ref(&c.rolling.filename_for(4)).exists());
         assert!(!AsRef::<Path>::as_ref(&c.rolling.filename_for(3)).exists());
@@ -431,16 +433,16 @@ mod t {
     fn frequency_every_hour() {
         let mut c = build_context(RollingConditionBasic::new().hourly(), 9, None);
         c.rolling
-            .write_with_datetime(b"Line 1\n", &Local.ymd(2021, 3, 30).and_hms(1, 2, 3))
+            .write_with_datetime(b"Line 1\n", &Local.with_ymd_and_hms(2021, 3, 30, 1, 2, 3).unwrap())
             .unwrap();
         c.rolling
-            .write_with_datetime(b"Line 2\n", &Local.ymd(2021, 3, 30).and_hms(1, 3, 2))
+            .write_with_datetime(b"Line 2\n", &Local.with_ymd_and_hms(2021, 3, 30, 1, 3, 2).unwrap())
             .unwrap();
         c.rolling
-            .write_with_datetime(b"Line 3\n", &Local.ymd(2021, 3, 30).and_hms(2, 1, 0))
+            .write_with_datetime(b"Line 3\n", &Local.with_ymd_and_hms(2021, 3, 30, 2, 1, 0).unwrap())
             .unwrap();
         c.rolling
-            .write_with_datetime(b"Line 4\n", &Local.ymd(2021, 3, 31).and_hms(2, 1, 0))
+            .write_with_datetime(b"Line 4\n", &Local.with_ymd_and_hms(2021, 3, 31, 2, 1, 0).unwrap())
             .unwrap();
         assert!(!AsRef::<Path>::as_ref(&c.rolling.filename_for(3)).exists());
         c.flush();
@@ -458,22 +460,22 @@ mod t {
             None,
         );
         c.rolling
-            .write_with_datetime(b"Line 1\n", &Local.ymd(2021, 3, 30).and_hms(1, 2, 3))
+            .write_with_datetime(b"Line 1\n", &Local.with_ymd_and_hms(2021, 3, 30, 1, 2, 3).unwrap())
             .unwrap();
         c.rolling
-            .write_with_datetime(b"Line 2\n", &Local.ymd(2021, 3, 30).and_hms(1, 2, 3))
+            .write_with_datetime(b"Line 2\n", &Local.with_ymd_and_hms(2021, 3, 30, 1, 2, 3).unwrap())
             .unwrap();
         c.rolling
-            .write_with_datetime(b"Line 3\n", &Local.ymd(2021, 3, 30).and_hms(1, 2, 4))
+            .write_with_datetime(b"Line 3\n", &Local.with_ymd_and_hms(2021, 3, 30, 1, 2, 4).unwrap())
             .unwrap();
         c.rolling
-            .write_with_datetime(b"Line 4\n", &Local.ymd(2021, 3, 30).and_hms(1, 3, 0))
+            .write_with_datetime(b"Line 4\n", &Local.with_ymd_and_hms(2021, 3, 30, 1, 3, 0).unwrap())
             .unwrap();
         c.rolling
-            .write_with_datetime(b"Line 5\n", &Local.ymd(2021, 3, 30).and_hms(2, 3, 0))
+            .write_with_datetime(b"Line 5\n", &Local.with_ymd_and_hms(2021, 3, 30, 2, 3, 0).unwrap())
             .unwrap();
         c.rolling
-            .write_with_datetime(b"Line 6\n", &Local.ymd(2022, 3, 30).and_hms(2, 3, 0))
+            .write_with_datetime(b"Line 6\n", &Local.with_ymd_and_hms(2022, 3, 30, 2, 3, 0).unwrap())
             .unwrap();
         assert!(!AsRef::<Path>::as_ref(&c.rolling.filename_for(4)).exists());
         c.flush();
@@ -489,19 +491,22 @@ mod t {
     fn max_size() {
         let mut c = build_context(RollingConditionBasic::new().max_size(10), 9, None);
         c.rolling
-            .write_with_datetime(b"12345", &Local.ymd(2021, 3, 30).and_hms(1, 2, 3))
+            .write_with_datetime(b"12345", &Local.with_ymd_and_hms(2021, 3, 30, 1, 2, 3).unwrap())
             .unwrap();
         c.rolling
-            .write_with_datetime(b"6789", &Local.ymd(2021, 3, 30).and_hms(1, 3, 3))
+            .write_with_datetime(b"6789", &Local.with_ymd_and_hms(2021, 3, 30, 1, 3, 3).unwrap())
             .unwrap();
         c.rolling
-            .write_with_datetime(b"0", &Local.ymd(2021, 3, 30).and_hms(2, 3, 3))
+            .write_with_datetime(b"0", &Local.with_ymd_and_hms(2021, 3, 30, 2, 3, 3).unwrap())
             .unwrap();
         c.rolling
-            .write_with_datetime(b"abcdefghijklmn", &Local.ymd(2021, 3, 31).and_hms(2, 3, 3))
+            .write_with_datetime(
+                b"abcdefghijklmn",
+                &Local.with_ymd_and_hms(2021, 3, 31, 2, 3, 3).unwrap(),
+            )
             .unwrap();
         c.rolling
-            .write_with_datetime(b"ZZZ", &Local.ymd(2022, 3, 31).and_hms(1, 2, 3))
+            .write_with_datetime(b"ZZZ", &Local.with_ymd_and_hms(2022, 3, 31, 1, 2, 3).unwrap())
             .unwrap();
         assert!(!AsRef::<Path>::as_ref(&c.rolling.filename_for(3)).exists());
         c.flush();
@@ -514,23 +519,26 @@ mod t {
     fn max_size_existing() {
         let mut c = build_context(RollingConditionBasic::new().max_size(10), 9, None);
         c.rolling
-            .write_with_datetime(b"12345", &Local.ymd(2021, 3, 30).and_hms(1, 2, 3))
+            .write_with_datetime(b"12345", &Local.with_ymd_and_hms(2021, 3, 30, 1, 2, 3).unwrap())
             .unwrap();
         // close the file and make sure that it can re-open it, and that it
         // resets the file size properly.
         c.rolling.writer_opt.take();
         c.rolling.current_filesize = 0;
         c.rolling
-            .write_with_datetime(b"6789", &Local.ymd(2021, 3, 30).and_hms(1, 3, 3))
+            .write_with_datetime(b"6789", &Local.with_ymd_and_hms(2021, 3, 30, 1, 3, 3).unwrap())
             .unwrap();
         c.rolling
-            .write_with_datetime(b"0", &Local.ymd(2021, 3, 30).and_hms(2, 3, 3))
+            .write_with_datetime(b"0", &Local.with_ymd_and_hms(2021, 3, 30, 2, 3, 3).unwrap())
             .unwrap();
         c.rolling
-            .write_with_datetime(b"abcdefghijklmn", &Local.ymd(2021, 3, 31).and_hms(2, 3, 3))
+            .write_with_datetime(
+                b"abcdefghijklmn",
+                &Local.with_ymd_and_hms(2021, 3, 31, 2, 3, 3).unwrap(),
+            )
             .unwrap();
         c.rolling
-            .write_with_datetime(b"ZZZ", &Local.ymd(2022, 3, 31).and_hms(1, 2, 3))
+            .write_with_datetime(b"ZZZ", &Local.with_ymd_and_hms(2022, 3, 31, 1, 2, 3).unwrap())
             .unwrap();
         assert!(!AsRef::<Path>::as_ref(&c.rolling.filename_for(3)).exists());
         c.flush();
@@ -543,19 +551,22 @@ mod t {
     fn daily_and_max_size() {
         let mut c = build_context(RollingConditionBasic::new().daily().max_size(10), 9, None);
         c.rolling
-            .write_with_datetime(b"12345", &Local.ymd(2021, 3, 30).and_hms(1, 2, 3))
+            .write_with_datetime(b"12345", &Local.with_ymd_and_hms(2021, 3, 30, 1, 2, 3).unwrap())
             .unwrap();
         c.rolling
-            .write_with_datetime(b"6789", &Local.ymd(2021, 3, 30).and_hms(2, 3, 3))
+            .write_with_datetime(b"6789", &Local.with_ymd_and_hms(2021, 3, 30, 2, 3, 3).unwrap())
             .unwrap();
         c.rolling
-            .write_with_datetime(b"0", &Local.ymd(2021, 3, 31).and_hms(2, 3, 3))
+            .write_with_datetime(b"0", &Local.with_ymd_and_hms(2021, 3, 31, 2, 3, 3).unwrap())
             .unwrap();
         c.rolling
-            .write_with_datetime(b"abcdefghijklmn", &Local.ymd(2021, 3, 31).and_hms(3, 3, 3))
+            .write_with_datetime(
+                b"abcdefghijklmn",
+                &Local.with_ymd_and_hms(2021, 3, 31, 3, 3, 3).unwrap(),
+            )
             .unwrap();
         c.rolling
-            .write_with_datetime(b"ZZZ", &Local.ymd(2021, 3, 31).and_hms(4, 4, 4))
+            .write_with_datetime(b"ZZZ", &Local.with_ymd_and_hms(2021, 3, 31, 4, 4, 4).unwrap())
             .unwrap();
         assert!(!AsRef::<Path>::as_ref(&c.rolling.filename_for(3)).exists());
         c.flush();
@@ -588,7 +599,7 @@ mod t {
         // implicit flush only after capacity is reached
         loop {
             c.rolling
-                .write_with_datetime(b"dummy", &Local.ymd(2021, 3, 30).and_hms(1, 2, 3))
+                .write_with_datetime(b"dummy", &Local.with_ymd_and_hms(2021, 3, 30, 1, 2, 3).unwrap())
                 .unwrap();
             if c.rolling.current_filesize <= 100_000 {
                 c.verify_not_contains("dummy", 0);
@@ -601,7 +612,7 @@ mod t {
         // explicit flush
         c.verify_not_contains("12345", 0);
         c.rolling
-            .write_with_datetime(b"12345", &Local.ymd(2021, 3, 30).and_hms(1, 2, 3))
+            .write_with_datetime(b"12345", &Local.with_ymd_and_hms(2021, 3, 30, 1, 2, 3).unwrap())
             .unwrap();
         c.flush();
         c.verify_contains("12345", 0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,14 +175,24 @@ where
 
     /// Creates a new rolling file appender with the given condition and write buffer capacity.
     /// The parent directory of the base path must already exist.
-    pub fn new_with_buffer_capacity<P>(path: P, condition: RC, max_files: usize, buffer_capacity: usize) -> io::Result<RollingFileAppender<RC>>
+    pub fn new_with_buffer_capacity<P>(
+        path: P,
+        condition: RC,
+        max_files: usize,
+        buffer_capacity: usize,
+    ) -> io::Result<RollingFileAppender<RC>>
     where
         P: AsRef<Path>,
     {
         Self::_new(path, condition, max_files, Some(buffer_capacity))
     }
 
-    fn _new<P>(path: P, condition: RC, max_files: usize, buffer_capacity: Option<usize>) -> io::Result<RollingFileAppender<RC>>
+    fn _new<P>(
+        path: P,
+        condition: RC,
+        max_files: usize,
+        buffer_capacity: Option<usize>,
+    ) -> io::Result<RollingFileAppender<RC>>
     where
         P: AsRef<Path>,
     {


### PR DESCRIPTION
we need to adjust the internal `BufWriter` capacity via its construction for best performance of super write intensive tasks: https://doc.rust-lang.org/std/io/struct.BufWriter.html#method.with_capacity

so, add another method, not to break compatibility.