### PR TITLE
Replace chrono with time (address RUSTSEC-2020-0071)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolling-file"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Kevin Hoffman <KevinJohnHoffman@gmail.com>"]
 edition = "2018"
 
@@ -15,6 +15,7 @@ license = "MIT/Apache-2.0"
 
 [dev-dependencies]
 tempfile = "3.0.5"
+time = { version = "0.3.17", features = ["local-offset", "macros"] }
 
 [dependencies]
-chrono = "0.4.23"
+time = { version = "0.3.17", features = ["local-offset"] }


### PR DESCRIPTION
This library is unfortunately more susceptible than normal to the env var race conditions in the RUSTSEC, because it uses local time calls extensively.

This PR addresses the vulnerability by replacing `chrono` with `time 0.3`. This is a semver breaking change, because it touches quite a few public interfaces.